### PR TITLE
(fix) Fixed issue when creating a grid referencing a form with no provided cfg

### DIFF
--- a/src/grid-utils/patientGridCreation.ts
+++ b/src/grid-utils/patientGridCreation.ts
@@ -108,7 +108,7 @@ export function getPatientGridColumnPostResourcesForForms(
         datatype: 'OBS',
         concept: question.questionOptions.concept,
         encounterType: form.encounterType.uuid,
-        hidden: new Set(formConfig.defaultHiddenQuestionIds).has(question.id),
+        hidden: new Set(formConfig?.defaultHiddenQuestionIds).has(question.id),
       };
     });
 


### PR DESCRIPTION
Fixed issue when creating a grid referencing a form with no provided cfg